### PR TITLE
[FIX] split-right && split-down mixup

### DIFF
--- a/keymaps/transient-emacs.cson
+++ b/keymaps/transient-emacs.cson
@@ -14,8 +14,8 @@
   'ctrl-x ctrl-f':'application:open'
   'ctrl-x ctrl-c':'application:quit'
 
-  'ctrl-x 2':'pane:split-right'
-  'ctrl-x 3':'pane:split-down'
+  'ctrl-x 3':'pane:split-right'
+  'ctrl-x 2':'pane:split-down'
   'ctrl-x 0':'pane:close'
   'ctrl-x o':'window:focus-next-pane'
 


### PR DESCRIPTION
emacs defaults are:

- `ctrl-3` : `split-right`
- `ctrl-2` : `split-down`

[source](http://www.gnu.org/software/emacs/manual/html_node/emacs/Split-Window.html)