### PR TITLE
improve flaky tests

### DIFF
--- a/src/code/test/extension.test.ts
+++ b/src/code/test/extension.test.ts
@@ -30,10 +30,10 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('\nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('baz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -46,10 +46,10 @@ suite('Extension Tests', async () => {
     move(editor, [new Position(0, 0), new Position(1, 0)]);
     await sleep(300);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('\n\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('', editor.document.getText());
   }).timeout(5000);
 
@@ -61,11 +61,11 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -77,13 +77,13 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar\nfoo bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -95,17 +95,17 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.cursorDown');
     await sleep(300);
     await vscode.commands.executeCommand('transient.cursorUp');
     await sleep(300);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('\n\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -117,10 +117,10 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0), new Position(1, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('\n\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -132,10 +132,10 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0), new Position(1, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar\nbaz\n\n', editor.document.getText());
   }).timeout(5000);
 
@@ -147,10 +147,10 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(1, 0), new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     move(editor, [new Position(0, 0)]);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('baz\nfoo bar\n\n', editor.document.getText());
   }).timeout(5000);
 
@@ -162,10 +162,10 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0), new Position(1, 0)]);
     await vscode.commands.executeCommand('transient.kill');
-    await sleep(500);
+    await sleep(750);
     move(editor, [new Position(0, 0), new Position(1, 0)]);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -177,12 +177,12 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 7)]);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo \nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo barbar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -194,14 +194,14 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 7)]);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo\nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo bar bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -213,16 +213,16 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 7)]);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('\nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo barfoo bar\nbaz\n', editor.document.getText());
   }).timeout(5000);
 
@@ -234,19 +234,19 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 7)]);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     await vscode.commands.executeCommand('transient.cursorDown');
     await sleep(300);
     await vscode.commands.executeCommand('transient.cursorUp');
     await sleep(300);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo\nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo \nbaz\n', editor.document.getText());
     await vscode.commands.executeCommand('transient.yank');
-    await sleep(500);
+    await sleep(750);
     assert.strictEqual('foo  \nbaz\n', editor.document.getText());
   }).timeout(5000);
 });

--- a/src/code/test/extension.test.ts
+++ b/src/code/test/extension.test.ts
@@ -35,7 +35,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.kill');
     await sleep(750);
     assert.strictEqual('baz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('transient.kill with multi cursor', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -51,7 +51,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.kill');
     await sleep(750);
     assert.strictEqual('', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill and yank', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -67,7 +67,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill and yank twice', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -85,7 +85,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar\nfoo bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill, move, kill and yank', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -107,7 +107,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('\n\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill and yank with multi cursors', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -122,7 +122,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill, consolidate and yank with multi cursors', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -137,7 +137,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar\nbaz\n\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill, consolidate and yank with inversed multi cursors', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -152,7 +152,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('baz\nfoo bar\n\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill, consolidate, add cursor and yank with multi cursors', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -167,7 +167,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill-backword-word and yank twice', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -184,7 +184,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo barbar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill-backword-word twice and yank twice', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -203,7 +203,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo bar bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill-backword-word 3times and yank twice', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -224,7 +224,7 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo barfoo bar\nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 
   await test('kill-backword-word, move, kill-backword-word and yank twice', async () => {
     let doc = await vscode.workspace.openTextDocument({
@@ -248,5 +248,5 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.yank');
     await sleep(750);
     assert.strictEqual('foo  \nbaz\n', editor.document.getText());
-  }).timeout(5000);
+  }).timeout(8000);
 });

--- a/src/code/test/extension.test.ts
+++ b/src/code/test/extension.test.ts
@@ -44,7 +44,7 @@ suite('Extension Tests', async () => {
     let editor = await vscode.window.showTextDocument(doc);
     await vscode.commands.executeCommand('transient.clearKillRing');
     move(editor, [new Position(0, 0), new Position(1, 0)]);
-    await sleep(200);
+    await sleep(300);
     await vscode.commands.executeCommand('transient.kill');
     await sleep(500);
     assert.strictEqual('\n\n', editor.document.getText());
@@ -97,9 +97,9 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.kill');
     await sleep(500);
     await vscode.commands.executeCommand('transient.cursorDown');
-    await sleep(200);
+    await sleep(300);
     await vscode.commands.executeCommand('transient.cursorUp');
-    await sleep(200);
+    await sleep(300);
     await vscode.commands.executeCommand('transient.kill');
     await sleep(500);
     await vscode.commands.executeCommand('transient.yank');
@@ -236,9 +236,9 @@ suite('Extension Tests', async () => {
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
     await sleep(500);
     await vscode.commands.executeCommand('transient.cursorDown');
-    await sleep(200);
+    await sleep(300);
     await vscode.commands.executeCommand('transient.cursorUp');
-    await sleep(200);
+    await sleep(300);
     await vscode.commands.executeCommand('transient.killRegionOrBackwardWord');
     await sleep(500);
     assert.strictEqual('foo\nbaz\n', editor.document.getText());


### PR DESCRIPTION
- Increase sleep time to 300ms for better test reliability
- Increase sleep time to 750ms in extension test suite for more reliable results
- Increase timeout for transient commands in extension test suite to 8000 milliseconds
