### PR TITLE
Preparing v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
-
 # Released
+
+See release notes on GitHub for 0.23.0 and later.
 
 ## 0.22.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.98.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "transient-emacs",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "transient-emacs",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "uuid": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "yasuyuky",
   "main": "./lib/code/extension",
   "browser": "./lib/web/extension",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "categories": [
     "Keymaps"
   ],

--- a/package.json
+++ b/package.json
@@ -450,7 +450,7 @@
   "icon": "image/icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.78.0"
+    "vscode": "^1.98.0"
   },
   "dependencies": {
     "uuid": "^11.1.0"


### PR DESCRIPTION
Update the version to 0.23.0 and change the VSCode engine requirement to ^1.98.0. Also, include release notes in the CHANGELOG for version 0.23.0 and later.