### PR TITLE
Align VS Code engine during release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,36 @@ jobs:
           echo version=${VERSION} >>$GITHUB_OUTPUT
           echo v=${TAG} >>$GITHUB_OUTPUT
 
+      - name: Sync VS Code engine
+        if: steps.release_window.outputs.should_release == 'true'
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+
+          const readJson = (file) => JSON.parse(fs.readFileSync(file, 'utf8'));
+          const writeJson = (file, data) => {
+            fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+          };
+
+          const manifest = readJson('package.json');
+          const vscode = manifest.devDependencies?.['@types/vscode'];
+
+          if (!vscode) {
+            throw new Error('@types/vscode is missing from devDependencies');
+          }
+
+          manifest.engines ??= {};
+          manifest.engines.vscode = vscode;
+          writeJson('package.json', manifest);
+
+          const lock = readJson('package-lock.json');
+          lock.packages ??= {};
+          lock.packages[''] ??= {};
+          lock.packages[''].engines ??= {};
+          lock.packages[''].engines.vscode = vscode;
+          writeJson('package-lock.json', lock);
+          NODE
+
       - name: Start xvfb
         if: steps.release_window.outputs.mode == 'scheduled'
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "vscode": "^1.98.0"
+        "vscode": "^1.118.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -450,7 +450,7 @@
   "icon": "image/icon.png",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.98.0"
+    "vscode": "^1.118.0"
   },
   "dependencies": {
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Summary
- Sync `engines.vscode` from `@types/vscode` inside the release workflow before packaging and publishing.
- Update `package.json` and `package-lock.json` to `^1.118.0` so release validation no longer fails on the engine mismatch.

## Testing
- `npm run compile`
- `npm test` (13 passing)
- `vsce package` validation passed after syncing the engine version