### PR TITLE
Seal the kill ring before transient cursor moves

### DIFF
--- a/src/code/extension.ts
+++ b/src/code/extension.ts
@@ -57,10 +57,16 @@ export function activate(context: vscode.ExtensionContext) {
 
   moves.forEach(move => {
     let key = 'transient.' + move;
-    let moveFunction = () => vscode.commands.executeCommand(markSet ? move + 'Select' : move);
+    let moveFunction = () => {
+      killRing.seal();
+      return vscode.commands.executeCommand(markSet ? move + 'Select' : move);
+    };
     let command = vscode.commands.registerTextEditorCommand(key, moveFunction);
     context.subscriptions.push(command);
-    let selectFunction = () => vscode.commands.executeCommand(move + 'Select');
+    let selectFunction = () => {
+      killRing.seal();
+      return vscode.commands.executeCommand(move + 'Select');
+    };
     let selectCommand = vscode.commands.registerTextEditorCommand(key + 'Select', selectFunction);
     context.subscriptions.push(selectCommand);
   });


### PR DESCRIPTION
**Summary**
- Seal the kill ring before `transient.cursor*` and `transient.cursor*Select` run so move commands no longer depend on selection-change timing.
- This removes the flaky path where a move on macOS could leave the kill ring unsealed and merge unrelated kills.

**Testing**
- `npm run compile`
- VS Code `1.121.0` integration tests passed locally (`13 passing`).